### PR TITLE
webhook endpoint as env_var_name

### DIFF
--- a/src/commands/trigger-pipeline-with-webhook.yml
+++ b/src/commands/trigger-pipeline-with-webhook.yml
@@ -5,7 +5,7 @@ parameters:
   webhook-endpoint:
     description: |
       Webhook endpoint
-    type: string
+    type: env_var_name
   payload:
     description: |
       JSON payload. Escaping of double quotes in the payload is required;


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Resolves #7 

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

change type `string` to `env_var_name`
