### PR TITLE
Use webhook enpoint value from ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ See the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/sp
 
 - Some of the commands require a Linux environment to execute in. Refer to the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/spinnaker) for the descriptions of each command.
 
+- `SPINNAKER_WEBHOOK` environment variable should be set in CircleCI project settings
+
 ## Examples
 
 Full usage examples can be found on the Spinnaker orb's page in the orb registry, [here](https://circleci.com/orbs/registry/orb/circleci/spinnaker#usage-examples).
@@ -57,7 +59,6 @@ jobs:
       # Send a request to a webhook endpoint pre-configured in Spinnaker
       # Ref: https://www.spinnaker.io/guides/user/pipeline/triggers/webhooks/
       - spinnaker/trigger-pipeline-with-webhook:
-          webhook-endpoint: "http://localhost:8084/webhooks/webhook/myappwebhook"
           payload: "{\\\"status\\\": \\\"success\\\", \\\"jobid\\\": \\\"$CIRCLE_WORKFLOW_JOB_ID\\\", \\\"message\\\": \\\"I've got it\\\"}"
 workflows:
   example-workflow:

--- a/src/commands/trigger-pipeline-with-webhook.yml
+++ b/src/commands/trigger-pipeline-with-webhook.yml
@@ -4,8 +4,11 @@ description: |
 parameters:
   webhook-endpoint:
     description: |
-      Webhook endpoint
-    type: string
+      Name of environment variable defined in CircleCI
+      containing the webhook endpoint URL pre-configured in Spinnaker
+      Example of value: http://localhost:8084/webhooks/webhook/myappwebhook
+    type: env_var_name
+    default: SPINNAKER_WEBHOOK
   payload:
     description: |
       JSON payload. Escaping of double quotes in the payload is required;
@@ -22,5 +25,10 @@ steps:
   - run:
       name: Trigger Spinnaker pipeline with webhook
       command: |
-        WEBHOOK_ENDPOINT="<< parameters.webhook-endpoint >>"
-        curl -X POST -H "content-type: application/json" -d "<< parameters.payload >>" ${WEBHOOK_ENDPOINT}
+        if [ -z "<< parameters.webhook-endpoint >>" ]; then
+          echo "No webhook endpoint url set"
+          echo "Please input your SPINNAKER_WEBHOOK value in the CircleCI settings for this project or as a parameter for this orb."
+          exit 1
+        else
+          curl -X POST -H "content-type: application/json" -d "<< parameters.payload >>" ${<< parameters.webhook-endpoint >>}
+        fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes #7 

### Description

- I've changed parameter type + updated description + added default value for parameter to be read for ENV based on https://circleci.com/docs/2.0/reusing-config/#environment-variable-name
- I removed explicit setting of `webhook-endpoint` parameter in examples

### Questions

- added check for parameter, but not able to test it locally without custom bash scripts, ideas?
- added webhook env variable name as `SPINNAKER_WEBHOOK`, not sure if it fits for you
