### PR TITLE
Fix dockerize timeout when Gate pod root endpoint is authenticated

### DIFF
--- a/src/commands/set-up-port-forwarding.yml
+++ b/src/commands/set-up-port-forwarding.yml
@@ -150,5 +150,5 @@ steps:
                 GATE_TARGET_PORT="${GATE_DEFAULT_TARGET_PORT}"
               fi
               dockerize -timeout 60s \
-                -wait ${DECK_PROTOCOL}://localhost:${DECK_TARGET_PORT}/health \
+                -wait ${DECK_PROTOCOL}://localhost:${DECK_TARGET_PORT} \
                 -wait ${GATE_PROTOCOL}://localhost:${GATE_TARGET_PORT}/health

--- a/src/commands/set-up-port-forwarding.yml
+++ b/src/commands/set-up-port-forwarding.yml
@@ -150,5 +150,5 @@ steps:
                 GATE_TARGET_PORT="${GATE_DEFAULT_TARGET_PORT}"
               fi
               dockerize -timeout 60s \
-                -wait ${DECK_PROTOCOL}://localhost:${DECK_TARGET_PORT} \
-                -wait ${GATE_PROTOCOL}://localhost:${GATE_TARGET_PORT}
+                -wait ${DECK_PROTOCOL}://localhost:${DECK_TARGET_PORT}/health \
+                -wait ${GATE_PROTOCOL}://localhost:${GATE_TARGET_PORT}/health


### PR DESCRIPTION
Addresses https://github.com/CircleCI-Public/spinnaker-orb/issues/16 by accessing a different endpoint to determine pod readiness
